### PR TITLE
Replace deep-equal with dequal

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 //index.js
-var deepEqual = require('deep-equal');
+var deepEqual = require('dequal');
 
 var Equality = function(opt) {
   this.precision = opt && opt.precision ? opt.precision : 17;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "deep-equal": "^1.0.0"
+    "dequal": "^2.0.3"
   },
   "devDependencies": {
     "browserify": "~5.10.1",


### PR DESCRIPTION
This PR replaces deep-equal with dequal, an alternative package with 0 dependencies (as opposed to 49: https://npmgraph.js.org/?q=deep-equal).